### PR TITLE
feat(eee-002): implement gap buffer with tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,16 +17,24 @@ cargo fmt --check    # Check formatting
 
 Eminix is a modern, performance-oriented, extensible text-based operating environment written in Rust, where text is the interface for everything. It targets the "advanced casual key presser" — users who want a single, powerful, keyboard-driven environment for diverse workflows (writing, research, file management, task tracking, and more). Think the vision of Emacs rebuilt on a modern foundation.
 
-Uses Rust edition 2024 with tokio for async runtime.
+Uses Rust edition 2024.
 
-## Architecture
+## Current State
+
+Implementing EEE 002 (The Provable Core). Currently:
+- `src/gap_buffer.rs` — gap buffer data structure with insert, delete, cursor movement, and auto-grow
+- `src/lib.rs` — library crate exposing `GapBuffer`
+- `tests/gap_buffer.rs` — integration tests (12 tests)
+- `doc/gap_buffer.md` — reference doc for the gap buffer design
+
+## Architecture (Planned)
 
 The design follows a **decentralized, event-driven, actor model** with a microkernel philosophy. Key architectural docs live in `eee/` as "EEE" (Eminix Enhancement EEE) proposals — start with `eee/EEE 001.md` for the full specification.
 
-### Core Concepts
+### Core Concepts (from EEE 001, not yet implemented)
 
-- **Event Priority System**: Events are either `Critical` (must never be dropped, e.g. user input) or `Ephemeral` (can be dropped under load, e.g. UI updates). This is the central QoS mechanism — see `src/events.rs`.
-- **EventBus** (`src/event_bus.rs`): Broadcast channel (tokio MPMC) for **ephemeral events only**. Critical events use separate lossless bounded channels with backpressure. The bus panics if you try to publish a Critical event on it.
+- **Event Priority System**: Events are either `Critical` (must never be dropped, e.g. user input) or `Ephemeral` (can be dropped under load, e.g. UI updates).
+- **EventBus**: Broadcast channel (tokio MPMC) for **ephemeral events only**. Critical events use separate lossless bounded channels with backpressure.
 - **Process Isolation**: UI runs as a separate process from the core daemon, communicating via IPC. A UI crash cannot corrupt editor state.
 - **Actor Isolation**: Components within the core are isolated actors with their own mailboxes and priority queues.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,3 @@
 name = "eminix"
 version = "0.1.0"
 edition = "2024"
-
-[dependencies]

--- a/doc/gap_buffer.md
+++ b/doc/gap_buffer.md
@@ -1,0 +1,60 @@
+# The Gap Buffer: A C Programmer's Mental Model
+
+Think of it as a `char buf[N]` with a hole in the middle. The cursor *is* the hole.
+
+```
+Index:   0     1     2     3     4     5     6     7
+Data:  [ a ] [ b ] [ ? ] [ ? ] [ ? ] [ c ] [ d ] [ e ]
+                   ^start             ^end
+                   |---- garbage -----|
+```
+
+**Two pointers, one rule:**
+- `start` = first index *of the gap* (garbage begins here)
+- `end` = first index *after the gap* (valid text resumes here)
+- Text = `buf[0..start]` + `buf[end..len]`. The gap is invisible to the user.
+
+**Invariant:** `start <= end`. When `start == end`, the gap is empty (needs grow).
+
+## Operations
+
+**Insert at cursor** — O(1). Drop the byte into the gap, advance `start`.
+```c
+buf[start] = byte;    /* gap's first slot is always free */
+start += 1;           /* gap shrinks from the left       */
+```
+
+**Delete before cursor (backspace)** — O(1). Just widen the gap leftward.
+```c
+start -= 1;           /* the byte at buf[start] is now "in the gap" */
+                      /* no memset needed -- gap is garbage anyway  */
+```
+
+**Move cursor left** — O(1). Slide one byte from before the gap to after the gap.
+```
+Before:  [ a ] [ b ] [ ??? ] [ c ] [ d ]
+                ^s-1   ^s      ^e
+
+end   -= 1;
+buf[end] = buf[start - 1];   /* move 'b' across the gap */
+start -= 1;
+
+After:   [ a ] [ ???? ] [ b ] [ c ] [ d ]
+                ^s        ^e
+```
+
+Key insight: `start - 1` is the last valid char before the gap.
+`end - 1` is the last garbage slot in the gap. No swap — gap is garbage.
+
+**Move cursor right** — O(1). Mirror of move left.
+```c
+buf[start] = buf[end];       /* move first char after gap to before it */
+start += 1;
+end   += 1;
+```
+
+## Why not just use an array with `memmove`?
+
+You could. That is what most editors did in the 1970s. The problem: inserting at position *k* in an array of *n* bytes costs O(n - k) because you `memmove` everything after *k*. A gap buffer pays this cost *only when the cursor jumps* to a distant position. Sequential typing (the common case) is always O(1).
+
+In C terms: the gap buffer trades `memmove` at every keystroke for `memmove` only on cursor jumps. For a typist, that is almost free.

--- a/src/gap_buffer.rs
+++ b/src/gap_buffer.rs
@@ -1,0 +1,91 @@
+/// A gap buffer for efficient text editing at the cursor position.
+///
+/// The buffer is a contiguous array with a "gap" where the cursor sits.
+/// Insertions and deletions at the cursor are O(1). Moving the cursor
+/// shifts elements across the gap.
+///
+/// Layout: [text before cursor ... GAP ... text after cursor]
+pub struct GapBuffer {
+    buffer: Vec<u8>,
+    start: usize,
+    end: usize,
+}
+
+impl GapBuffer {
+    /// Create a new empty gap buffer with the given initial gap capacity.
+    pub fn new(capacity: usize) -> Self {
+        assert!(capacity > 0, "capacity must be non-zero");
+        Self {
+            buffer: vec![0u8; capacity],
+            start: 0,
+            end: capacity,
+        }
+    }
+
+    /// Insert a byte at the cursor position.
+    pub fn insert(&mut self, byte: u8) {
+        if self.start == self.end {
+            let old_capacity = self.buffer.len();
+            let new_capacity = old_capacity * 2;
+            self.buffer.resize(new_capacity, 0);
+            self.buffer.copy_within(
+                self.end..old_capacity,
+                new_capacity - old_capacity + self.end,
+            );
+            self.end += new_capacity - old_capacity;
+        }
+        self.buffer[self.start] = byte;
+        self.start += 1;
+    }
+
+    /// Delete the byte immediately before the cursor (backspace).
+    /// Returns the deleted byte, or None if the cursor is at the start.
+    pub fn delete(&mut self) -> Option<u8> {
+        if self.start == 0 {
+            return None;
+        }
+        self.start -= 1;
+        Some(self.buffer[self.start])
+    }
+
+    /// Move the cursor one position to the left.
+    /// Returns false if already at the start.
+    pub fn move_left(&mut self) -> bool {
+        if self.start == 0 {
+            return false;
+        }
+        self.buffer[self.end - 1] = self.buffer[self.start - 1];
+        self.start -= 1;
+        self.end -= 1;
+        true
+    }
+
+    /// Move the cursor one position to the right.
+    /// Returns false if already at the end.
+    pub fn move_right(&mut self) -> bool {
+        if self.end == self.buffer.len() {
+            return false;
+        }
+        self.buffer[self.start] = self.buffer[self.end];
+        self.start += 1;
+        self.end += 1;
+        true
+    }
+
+    /// Return the full buffer contents as a Vec<u8>, skipping the gap.
+    pub fn contents(&self) -> Vec<u8> {
+        let mut result = self.buffer[..self.start].to_vec();
+        result.extend_from_slice(&self.buffer[self.end..]);
+        result
+    }
+
+    /// The number of actual bytes in the buffer (excluding the gap).
+    pub fn len(&self) -> usize {
+        self.buffer.len() - self.end + self.start
+    }
+
+    /// Whether the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod gap_buffer;
+
+pub use gap_buffer::GapBuffer;

--- a/tests/gap_buffer.rs
+++ b/tests/gap_buffer.rs
@@ -1,0 +1,109 @@
+use eminix::GapBuffer;
+
+#[test]
+fn new_buffer_is_empty() {
+    let buf = GapBuffer::new(16);
+    assert!(buf.is_empty());
+    assert_eq!(buf.len(), 0);
+    assert_eq!(buf.contents(), vec![]);
+}
+
+#[test]
+fn insert_single_char() {
+    let mut buf = GapBuffer::new(16);
+    buf.insert(b'a');
+    assert_eq!(buf.contents(), b"a");
+    assert_eq!(buf.len(), 1);
+}
+
+#[test]
+fn insert_multiple_chars() {
+    let mut buf = GapBuffer::new(16);
+    for &ch in b"hello" {
+        buf.insert(ch);
+    }
+    assert_eq!(buf.contents(), b"hello");
+}
+
+#[test]
+fn delete_removes_char_before_cursor() {
+    let mut buf = GapBuffer::new(16);
+    for &ch in b"abc" {
+        buf.insert(ch);
+    }
+    let deleted = buf.delete();
+    assert_eq!(deleted, Some(b'c'));
+    assert_eq!(buf.contents(), b"ab");
+}
+
+#[test]
+fn delete_on_empty_returns_none() {
+    let mut buf = GapBuffer::new(16);
+    assert_eq!(buf.delete(), None);
+}
+
+#[test]
+fn move_left_then_insert() {
+    let mut buf = GapBuffer::new(16);
+    for &ch in b"ac" {
+        buf.insert(ch);
+    }
+    buf.move_left();
+    buf.insert(b'b');
+    assert_eq!(buf.contents(), b"abc");
+}
+
+#[test]
+fn move_right_after_move_left() {
+    let mut buf = GapBuffer::new(16);
+    for &ch in b"abc" {
+        buf.insert(ch);
+    }
+    buf.move_left();
+    buf.move_left();
+    buf.move_right();
+    buf.insert(b'X');
+    assert_eq!(buf.contents(), b"abXc");
+}
+
+#[test]
+fn move_left_at_start_returns_false() {
+    let mut buf = GapBuffer::new(16);
+    assert!(!buf.move_left());
+}
+
+#[test]
+fn move_right_at_end_returns_false() {
+    let mut buf = GapBuffer::new(16);
+    buf.insert(b'a');
+    assert!(!buf.move_right());
+}
+
+#[test]
+fn delete_in_the_middle() {
+    let mut buf = GapBuffer::new(16);
+    for &ch in b"abcd" {
+        buf.insert(ch);
+    }
+    buf.move_left();
+    buf.move_left();
+    let deleted = buf.delete();
+    assert_eq!(deleted, Some(b'b'));
+    assert_eq!(buf.contents(), b"acd");
+}
+
+#[test]
+fn insert_beyond_initial_capacity() {
+    let mut buf = GapBuffer::new(4);
+    for &ch in b"hello world" {
+        buf.insert(ch);
+    }
+    assert_eq!(buf.contents(), b"hello world");
+    assert_eq!(buf.len(), 11);
+}
+
+#[test]
+#[should_panic(expected = "capacity must be non-zero")]
+fn new_with_zero_capacity_panics() {
+    GapBuffer::new(0);
+}


### PR DESCRIPTION
First component of the Provable Core milestone. Gap buffer supports
insert, delete, cursor movement (left/right), auto-grow on capacity
exhaustion, and full content retrieval. 12 integration tests covering
correctness and edge cases. Includes reference doc for the data structure.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
